### PR TITLE
Add migration_repo options

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -15,6 +15,10 @@ defmodule Ecto.Migration do
   that have already been executed. You can configure the name of
   this table with the `:migration_source` configuration option.
 
+  You can configure a different database for the table that
+  manages your migrations by setting the `:migration_repo`
+  configuration option to a different repository.
+
   Ecto also locks the `schema_migrations` table when running
   migrations, guaranteeing two different servers cannot run the same
   migration at the same time.
@@ -154,8 +158,8 @@ defmodule Ecto.Migration do
   terminates.
 
   However, in some situations you may want to guarantee that all of the
-  previous steps have been executed before continuing. This is useful when 
-  you need to apply a set of changes to the table before continuing with the 
+  previous steps have been executed before continuing. This is useful when
+  you need to apply a set of changes to the table before continuing with the
   migration. This can be done with `flush/0`:
 
       def up do
@@ -213,6 +217,12 @@ defmodule Ecto.Migration do
       migrations, but you can configure it via:
 
           config :app, App.Repo, migration_default_prefix: "my_prefix"
+
+    * `:migration_repo` - Ecto defaults to the repository that is being configured. The
+      migration repository is where the table managing the migrations will be stored
+      (`migration_source` defines the table name). You can configure the repository via:
+
+          config :app, App.Repo, migration_repo: App.MigrationRepo
 
     * `:priv` - the priv diretory for the repo with the location of important assets,
       such as migrations. For a repository named `MyApp.FooRepo`, `:priv` defaults to

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -292,7 +292,7 @@ defmodule Ecto.Migrator do
       try do
         # The table with schema migrations can only be updated from
         # the parent process because it has a lock on the table
-        verbose_schema_migration migration_repo, "update schema migrations", fn ->
+        verbose_schema_migration repo, "update schema migrations", fn ->
           apply(SchemaMigration, direction, [migration_repo, version, opts[:prefix]])
         end
       catch
@@ -651,10 +651,11 @@ defmodule Ecto.Migrator do
 
         To address the second, you can run "mix ecto.drop" followed by
         "mix ecto.create". Alternatively you may configure Ecto to use
-        another table for managing migrations:
+        another table and/or repo for managing migrations:
 
             config #{inspect repo.config[:otp_app]}, #{inspect repo},
-              migration_source: "some_other_table_for_schema_migrations"
+              migration_source: "some_other_table_for_schema_migrations",
+              migration_repo: AnotherRepoForSchemaMigrations
 
         The full error report is shown below.
         """

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -138,7 +138,7 @@ defmodule Ecto.Migrator do
 
     case repo.start_link(pool_size: pool_size) do
       {:ok, _} ->
-        ensure_migration_repo_started(repo, repo.config[:migration_repo])
+        ensure_migration_repo_started(repo, repo.config[:migration_repo] || repo)
         try do
           {:ok, fun.(repo), started}
         after
@@ -146,7 +146,7 @@ defmodule Ecto.Migrator do
         end
 
       {:error, {:already_started, _pid}} ->
-        ensure_migration_repo_started(repo, repo.config[:migration_repo])
+        ensure_migration_repo_started(repo, repo.config[:migration_repo] || repo)
         try do
           {:ok, fun.(repo), started}
         after
@@ -673,10 +673,6 @@ defmodule Ecto.Migrator do
   defp log(level, msg),  do: Logger.log(level, msg)
 
   defp ensure_migration_repo_started(repo, repo) do
-    :ok
-  end
-
-  defp ensure_migration_repo_started(_repo, nil) do
     :ok
   end
 

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -138,6 +138,7 @@ defmodule Ecto.Migrator do
 
     case repo.start_link(pool_size: pool_size) do
       {:ok, _} ->
+        ensure_migration_repo_started(repo, repo.config[:migration_repo])
         try do
           {:ok, fun.(repo), started}
         after
@@ -145,6 +146,7 @@ defmodule Ecto.Migrator do
         end
 
       {:error, {:already_started, _pid}} ->
+        ensure_migration_repo_started(repo, repo.config[:migration_repo])
         try do
           {:ok, fun.(repo), started}
         after
@@ -670,4 +672,25 @@ defmodule Ecto.Migrator do
 
   defp log(false, _msg), do: :ok
   defp log(level, msg),  do: Logger.log(level, msg)
+
+  defp ensure_migration_repo_started(repo, repo) do
+    :ok
+  end
+
+  defp ensure_migration_repo_started(_repo, nil) do
+    :ok
+  end
+
+  defp ensure_migration_repo_started(_repo, migration_repo) do
+    case migration_repo.start_link() do
+      {:ok, _} ->
+        :ok
+
+      {:error, {:already_started, _pid}} ->
+        :ok
+
+      {:error, _} = error ->
+        error
+    end
+  end
 end

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -288,7 +288,6 @@ defmodule Ecto.Migrator do
     dynamic_repo = repo.get_dynamic_repo()
     task = Task.async(fn -> run_maybe_in_transaction(parent, ref, repo, dynamic_repo, module, fun) end)
 
-
     if migrated_successfully?(ref, task.pid) do
       try do
         # The table with schema migrations can only be updated from

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -651,7 +651,7 @@ defmodule Ecto.Migrator do
 
         To address the second, you can run "mix ecto.drop" followed by
         "mix ecto.create". Alternatively you may configure Ecto to use
-        another table and/or repo for managing migrations:
+        another table and/or repository for managing migrations:
 
             config #{inspect repo.config[:otp_app]}, #{inspect repo},
               migration_source: "some_other_table_for_schema_migrations",

--- a/test/ecto/migrator_repo_test.exs
+++ b/test/ecto/migrator_repo_test.exs
@@ -4,9 +4,6 @@ defmodule Ecto.MigratorRepoTest do
   import Ecto.Migrator
   import ExUnit.CaptureLog
 
-  alias EctoSQL.TestRepo
-  alias EctoSQL.MigrationTestRepo
-
   defmodule Migration do
     use Ecto.Migration
 
@@ -31,6 +28,16 @@ defmodule Ecto.MigratorRepoTest do
     end
   end
 
+  defmodule MainRepo do
+    use Ecto.Repo, otp_app: :ecto_sql, adapter: EctoSQL.TestAdapter
+  end
+
+  defmodule MigrationRepo do
+    use Ecto.Repo, otp_app: :ecto_sql, adapter: EctoSQL.TestAdapter
+  end
+
+  Application.put_env(:ecto_sql, MainRepo, [migration_repo: MigrationRepo])
+
   setup do
     Process.put(:migrated_versions, [1, 2, 3])
     :ok
@@ -44,29 +51,35 @@ defmodule Ecto.MigratorRepoTest do
     end
   end
 
+  setup_all do
+    {:ok, _pid} = MainRepo.start_link()
+    {:ok, _pid} = MigrationRepo.start_link()
+    :ok
+  end
+
   describe "migration_repo option" do
     test "upwards and downwards migrations" do
-      assert run(TestRepo, [{3, ChangeMigration}, {4, Migration}], :up, to: 4, log: false, migration_repo: MigrationTestRepo) == [4]
-      assert run(TestRepo, [{2, ChangeMigration}, {3, Migration}], :down, all: true, log: false, migration_repo: MigrationTestRepo) == [3, 2]
+      assert run(MainRepo, [{3, ChangeMigration}, {4, Migration}], :up, to: 4, log: false) == [4]
+      assert run(MainRepo, [{2, ChangeMigration}, {3, Migration}], :down, all: true, log: false) == [3, 2]
     end
 
     test "down invokes the repository adapter with down commands" do
-      assert down(TestRepo, 0, Migration, log: false, migration_repo: MigrationTestRepo) == :already_down
-      assert down(TestRepo, 2, Migration, log: false, migration_repo: MigrationTestRepo) == :ok
+      assert down(MainRepo, 0, Migration, log: false) == :already_down
+      assert down(MainRepo, 2, Migration, log: false) == :ok
     end
 
     test "up invokes the repository adapter with up commands" do
-      assert up(TestRepo, 3, Migration, log: false, migration_repo: MigrationTestRepo) == :already_up
-      assert up(TestRepo, 4, Migration, log: false, migration_repo: MigrationTestRepo) == :ok
+      assert up(MainRepo, 3, Migration, log: false) == :already_up
+      assert up(MainRepo, 4, Migration, log: false) == :ok
     end
 
-    test "migrations run inside a transaction if the adapter supports ddl transactions" do
+    test "migrations run inside a transaction if the adapter supports ddl transactions when configuring a migration repo" do
       capture_log fn ->
         put_test_adapter_config(supports_ddl_transaction?: true, test_process: self())
-        up(TestRepo, 0, Migration, migration_repo: MigrationTestRepo)
+        up(MainRepo, 0, Migration)
 
-        assert_receive {:transaction, %{repo: TestRepo}, _}
-        assert_receive {:lock_for_migrations, %{repo: MigrationTestRepo}, _}
+        assert_receive {:transaction, %{repo: MainRepo}, _}
+        assert_receive {:lock_for_migrations, %{repo: MigrationRepo}, _}
       end
     end
   end

--- a/test/ecto/migrator_test.exs
+++ b/test/ecto/migrator_test.exs
@@ -337,18 +337,18 @@ defmodule Ecto.MigratorTest do
 
     test "on up" do
       assert up(TestRepo, 9, Migration, log: false) == :ok
-      assert_receive {:lock_for_migrations, _}
+      assert_receive {:lock_for_migrations, _, _}
 
       assert up(TestRepo, 10, NoLockMigration, log: false) == :ok
-      refute_received {:lock_for_migrations, _}
+      refute_received {:lock_for_migrations, _, _}
     end
 
     test "on down" do
       assert down(TestRepo, 1, Migration, log: false) == :ok
-      assert_receive {:lock_for_migrations, _}
+      assert_receive {:lock_for_migrations, _, _}
 
       assert down(TestRepo, 2, NoLockMigration, log: false) == :ok
-      refute_received {:lock_for_migrations, _}
+      refute_received {:lock_for_migrations, _, _}
     end
 
     test "on run" do
@@ -356,14 +356,14 @@ defmodule Ecto.MigratorTest do
         create_migration "13_sample.exs"
         assert run(TestRepo, path, :up, all: true, log: false) == [13]
         # One lock for fetching versions, another for running
-        assert_receive {:lock_for_migrations, _}
-        assert_receive {:lock_for_migrations, _}
+        assert_receive {:lock_for_migrations, _, _}
+        assert_receive {:lock_for_migrations, _, _}
 
         create_migration "14_sample.exs", [:disable_migration_lock]
         assert run(TestRepo, path, :up, all: true, log: false) == [14]
         # One lock for fetching versions, another from running
-        assert_receive {:lock_for_migrations, _}
-        refute_received {:lock_for_migrations, _}
+        assert_receive {:lock_for_migrations, _, _}
+        refute_received {:lock_for_migrations, _, _}
       end
     end
   end
@@ -534,7 +534,7 @@ defmodule Ecto.MigratorTest do
       capture_log fn ->
         put_test_adapter_config(supports_ddl_transaction?: true, test_process: self())
         up(TestRepo, 0, ChangeMigration)
-        assert_receive {:transaction, _}
+        assert_receive {:transaction, _, _}
       end
     end
 

--- a/test/test_repo.exs
+++ b/test/test_repo.exs
@@ -49,9 +49,9 @@ defmodule EctoSQL.TestAdapter do
 
   def in_transaction?(_), do: Process.get(:in_transaction?) || false
 
-  def transaction(_mod, _opts, fun) do
+  def transaction(mod, _opts, fun) do
     Process.put(:in_transaction?, true)
-    send test_process(), {:transaction, fun}
+    send test_process(), {:transaction, mod, fun}
     {:ok, fun.()}
   after
     Process.put(:in_transaction?, false)
@@ -59,8 +59,8 @@ defmodule EctoSQL.TestAdapter do
 
   ## Migrations
 
-  def lock_for_migrations(_, query, _opts, fun) do
-    send test_process(), {:lock_for_migrations, fun}
+  def lock_for_migrations(mod, query, _opts, fun) do
+    send test_process(), {:lock_for_migrations, mod, fun}
     fun.(query)
   end
 
@@ -92,5 +92,10 @@ defmodule EctoSQL.TestRepo do
   use Ecto.Repo, otp_app: :ecto_sql, adapter: EctoSQL.TestAdapter
 end
 
+defmodule EctoSQL.MigrationTestRepo do
+  use Ecto.Repo, otp_app: :ecto_sql, adapter: EctoSQL.TestAdapter
+end
+
 EctoSQL.TestRepo.start_link()
 EctoSQL.TestRepo.start_link(name: :tenant_db)
+EctoSQL.MigrationTestRepo.start_link()


### PR DESCRIPTION
We decided to add a community-master branch so that we can use that temporarily as the branch hermes uses. This PR is for us to get moving internally, and we will do a separate one based off of this at a later time to the main ecto-sql repository.

https://www.pivotaltracker.com/story/show/170831452